### PR TITLE
docs: Fix project name and license link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ### License
 
-<PROJECT NAME> is licensed under the terms in [LICENSE]<link to license file in repo>. By contributing to the project, you agree to the license and copyright terms therein and release your contribution under these terms.
+MFD is licensed under the terms in [LICENSE](LICENSE.md). By contributing to the project, you agree to the license and copyright terms therein and release your contribution under these terms.
 
 ### Sign your work
 


### PR DESCRIPTION
This pull request updates the licensing information in the `CONTRIBUTING.md` file to reflect the correct project name and license file link.

* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L5-R5): Changed `<PROJECT NAME>` to `MFD` and updated the license file reference from `<link to license file in repo>` to `LICENSE.MD`.