### PR TITLE
fix: Fixed PR pip install command

### DIFF
--- a/.github/workflows/build_upload_whl.yml
+++ b/.github/workflows/build_upload_whl.yml
@@ -128,7 +128,7 @@ jobs:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const prNumber = context.payload.pull_request.number;
-            const commentBody = "We don't publish DEVs .whl.\n To build .whl, run 'pip install git+https://${{ inputs.REPOSITORY_NAME }}@${{ inputs.BRANCH_NAME }}'";
+            const commentBody = "We don't publish DEVs .whl.\n To build .whl, run 'pip install git+https://github.com/${{ inputs.REPOSITORY_NAME }}@${{ inputs.BRANCH_NAME }}'";
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,


### PR DESCRIPTION
This pull request makes a minor update to the workflow comment in `.github/workflows/build_upload_whl.yml`, correcting the URL used in the pip install command to include the correct GitHub domain.

* Updated the pip install command in the workflow comment to use `github.com` in the repository URL, ensuring users receive accurate instructions.