### PR TITLE
ci: update python-semantic-release version to 10.5.3 in workflows

### DIFF
--- a/.github/workflows/build_upload_whl.yml
+++ b/.github/workflows/build_upload_whl.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Run python-semantic-release without version bump - force patch bump
         if: env.CREATE_WHL == 'false'
-        uses: python-semantic-release/python-semantic-release@v10.3.1
+        uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
           build: true
           vcs_release: false
@@ -102,7 +102,7 @@ jobs:
 
       - name: Run python-semantic-release
         if: env.CREATE_WHL == 'true'
-        uses: python-semantic-release/python-semantic-release@v10.3.1
+        uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
           build: true
           vcs_release: false

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -43,7 +43,7 @@ jobs:
         mfd-create-config-files --project-dir .
     - name: Run python-semantic-release
       id: semantic_release
-      uses: python-semantic-release/python-semantic-release@v10.3.1
+      uses: python-semantic-release/python-semantic-release@v10.5.3
       with:
         build: false
         vcs_release: true


### PR DESCRIPTION
This pull request updates the version of the `python-semantic-release` GitHub Action used in our workflow configuration files. The action is upgraded from version 10.3.1 to 10.5.3 across all relevant jobs to ensure we benefit from the latest features and fixes.

Dependency updates:

* Upgraded `python-semantic-release/python-semantic-release` from version 10.3.1 to 10.5.3 in `.github/workflows/build_upload_whl.yml` for both the "Run python-semantic-release without version bump" and "Run python-semantic-release" jobs. [[1]](diffhunk://#diff-f9a58bb8a7eca2cdffe1f8c8e5f40fc34a868f284c1101be4a24a4b729db75b2L95-R95) [[2]](diffhunk://#diff-f9a58bb8a7eca2cdffe1f8c8e5f40fc34a868f284c1101be4a24a4b729db75b2L105-R105)
* Upgraded `python-semantic-release/python-semantic-release` from version 10.3.1 to 10.5.3 in `.github/workflows/publish_release.yml`.
Change comes from tomlkit bug in 0.15 https://github.com/python-poetry/tomlkit/issues/482